### PR TITLE
Convert to Koa v2.x middleware style

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = serve
  * @api public
  */
 
-async function serve (opts) {
-    assert(typeof options.rootDir === 'string', 'rootDir must be specified (as a string)')
+function serve (opts) {
+    assert(typeof opts.rootDir === 'string', 'rootDir must be specified (as a string)')
 
     let options = opts || {}
     options.root = path.resolve(options.rootDir || process.cwd())
@@ -37,7 +37,7 @@ async function serve (opts) {
         'web/file.txt' will be served as 'http://host/file.txt'
         */
         assert(ctx, 'koa context requried')
-        let path = this.path
+        let path = ctx.path
         if (!options.rootPath) {
             log && console.log(new Date().toISOString(), path)
             const sent = await send(ctx, path, options)
@@ -46,28 +46,28 @@ async function serve (opts) {
             else
                 return next()
         }
-    
+
         // Check if request path (eg: /doc/file.html) is allowed (eg. in /doc)
         if (path.indexOf(options.rootPath) !== 0)
             return next()
-    
+
         /* Serve folders as specified
          eg. for options:
             rootDir = 'web/static'
             rootPath = '/static'
-    
+
         'web/static/file.txt' will be served as 'http://server/static/file.txt'
         */
-    
+
         // Redirect non-slashed request to slashed
         // eg. /doc to /doc/
-    
+
         if (path === options.rootPath)
             return this.redirect(normalize(options.rootPath + "/"))
-    
+
         if (options.rootPath)
             path = normalize(path.replace(options.rootPath, "/"))
-    
+
         log && console.log(new Date().toISOString(), path)
         const sent = await send(ctx, path, options)
         if (sent)
@@ -76,3 +76,4 @@ async function serve (opts) {
             return next()
     }
 }
+

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  * Module dependencies
  */
 
+const assert = require('assert')
 const send = require('koa-send')
 const normalize = require('path').normalize
 const path = require('path')
@@ -21,58 +22,57 @@ module.exports = serve
  * @api public
  */
 
-function serve(opts) {
+async function serve (opts) {
+    assert(typeof options.rootDir === 'string', 'rootDir must be specified (as a string)')
 
     let options = opts || {}
     options.root = path.resolve(options.rootDir || process.cwd())
     options.index = options.index || "index.html"
-    let log = options.log || false
+    const log = options.log || false
 
-    if (typeof options.rootDir !== 'string')
-        throw Error('rootDir must be specified')
-
-    return function*(next) {
+    return async (ctx, next) => {
         /* Serve folder as root path - default
          eg. for options
             rootDir = 'web'
         'web/file.txt' will be served as 'http://host/file.txt'
         */
+        assert(ctx, 'koa context requried')
         let path = this.path
         if (!options.rootPath) {
             log && console.log(new Date().toISOString(), path)
-            const sent = yield send(this, path, options)
+            const sent = await send(ctx, path, options)
             if (sent)
                 return
             else
-                return yield *next
+                return next()
         }
-
+    
         // Check if request path (eg: /doc/file.html) is allowed (eg. in /doc)
         if (path.indexOf(options.rootPath) !== 0)
-            return yield *next
-
+            return next()
+    
         /* Serve folders as specified
          eg. for options:
             rootDir = 'web/static'
             rootPath = '/static'
-
+    
         'web/static/file.txt' will be served as 'http://server/static/file.txt'
         */
-
+    
         // Redirect non-slashed request to slashed
         // eg. /doc to /doc/
-
+    
         if (path === options.rootPath)
             return this.redirect(normalize(options.rootPath + "/"))
-
+    
         if (options.rootPath)
             path = normalize(path.replace(options.rootPath, "/"))
-
+    
         log && console.log(new Date().toISOString(), path)
-        const sent = yield send(this,  path, options)
+        const sent = await send(ctx, path, options)
         if (sent)
             return
         else
-            return yield *next
+            return next()
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-static-server",
   "description": "Static file serving middleware for koa with directory, rewrite and index support",
   "repository": "https://github.com/pkoretic/koa-static-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [
     "koa",
     "middleware",


### PR DESCRIPTION
This module was giving warnings when used with recent versions of Koa.  I migrated the module to Koa 2.x middleware style per the official guide https://github.com/koajs/koa/blob/master/docs/migration.md