### PR TITLE
Fixes 'this' context to proper 'ctx', adds 'notFoundFile' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ app.use(require('koa-static-server')(options))
 
  - `rootDir` {string} directory that is to be served
  - `rootPath` {string} optional rewrite path
+ - `notFoundFile` {string} optional default file to serve if requested static is missing
  - `log` {boolean} request access log to console
  - `maxage` Browser cache max-age in milliseconds. defaults to 0
  - `hidden` Allow transfer of hidden files. defaults to false
@@ -83,4 +84,3 @@ console.log('listening on port 3000')
 ## License
 
   MIT
-


### PR DESCRIPTION
This PR fixes issue with `this` context inside `serve()` function which in case of heavy router path matching (regexp, for example) could cause undefined error.

Also, added new optional argument `notFoundFile` which would allow default file or page served instead of unexisting file - useful for custom not found pages or images that illustrates the error.