### PR TITLE
Use upath to achieve cross-platform compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 const assert = require('assert')
 const send = require('koa-send')
-const normalize = require('path').normalize
+const normalize = require('upath').normalizeSafe
 const path = require('path')
 
 module.exports = serve

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "koa-send": "~4.1.0"
+    "koa-send": "~4.1.0",
+    "upath": "^1.0.2"
   }
 }


### PR DESCRIPTION
I ran into an issue with using this package on both Linux and Windows.  On Linux, everything was great.  However, on Windows, when trying to serve my files, the directory paths (specifically the seprators, \ vs. /) got messed up, even though I didn't hard-code any Linux separators in my app (the separators came from the browser URL, which obviously uses /'s).  By using upath's normalizeSafe, we solve this issue (everything now seems cross-platform compatible as far as I can tell).  Let me know your feedback, thanks!